### PR TITLE
BUG: Fix menu-icon to work with 3.1

### DIFF
--- a/code/TaxonomyAdmin.php
+++ b/code/TaxonomyAdmin.php
@@ -12,6 +12,8 @@ class TaxonomyAdmin extends ModelAdmin {
 	private static $managed_models = array('TaxonomyTerm');
 
 	private static $menu_title = 'Taxonomies';
+	
+	private static $menu_icon = "taxonomy/images/tag.png";
 
 	public function getList() {
 		$list = parent::getList();

--- a/css/TaxonomyAdmin.css
+++ b/css/TaxonomyAdmin.css
@@ -1,3 +1,0 @@
-.icon-taxonomyadmin.icon-16 {
-	background: url("../images/tag.png");
-}


### PR DESCRIPTION
3.1 beta-3 defines a default icon as a static. This overrides the supplied css file, as the code generated by the static appears as embedded css.
