### PR TITLE
Default directory implementation

### DIFF
--- a/code/controllers/TaxonomyDirectoryController.php
+++ b/code/controllers/TaxonomyDirectoryController.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Class TaxonomyDirectoryController
+ *
+ * Controller for returning a list of pages tagged with a specific Taxonomy Term
+ */
+class TaxonomyDirectoryController extends Page_Controller
+{
+
+    private static $allowed_actions = array(
+        'index'
+    );
+
+    public function index(SS_HTTPRequest $HTTPRequest)
+    {
+        $termString = $HTTPRequest->param('ID');
+
+        $pages = Page::get()
+            ->innerJoin(
+                'BasePage_Terms',
+                '"Page"."ID"="BasePage_Terms"."BasePageID"')
+            ->innerJoin(
+                'TaxonomyTerm',
+                "\"BasePage_Terms\".\"TaxonomyTermID\"=\"TaxonomyTerm\".\"ID\" AND \"TaxonomyTerm\".\"Name\" = '$termString'");
+
+        return $this->customise(new ArrayData(array(
+            'Title' => $termString,
+            'Term' => $termString,
+            'Pages' => $pages,
+            'Breadcrumbs' => $this->renderBreadcrumb($termString)
+        )))->renderWith(array("TaxonomyDirectory", "Page"));
+    }
+
+    protected function renderBreadcrumb($termString)
+    {
+        $page = new Page();
+        $page->Title = $termString;
+
+        $template = new SSViewer('BreadcrumbsTemplate');
+        return $template->process($this->customise(new ArrayData(array(
+            "Pages" => new ArrayList(array($page))
+        ))));
+    }
+
+}
+

--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -147,6 +147,7 @@ This will work for a single term. You could add more complex SQL to get any from
 You might want a page that acts as a parent to all pages with a certain tag. This way it can act as a dynamic directory
 that will always display content about a certain topic, automatically adding pages as they get created.
 
+### Using a custom page type
 To do so, you'll need to create a new page type (called `TaxonomyDirectory` here) and specify the tag or tags that
 you'd like the page to display. In this example we'll just re-use the existing many-many relationship on `Page` but if
 it's necessary for you to have two then you can create an extra many-many relationship.
@@ -182,3 +183,46 @@ class TaxonomyDirectory_Controller extends Page_Controller
 
 }
 ```
+
+### Using the provided default controller implementation
+If you want to use the provided directory implementation named `TaxonomyDirectoryController`, more or less based on the previous example, the only thing
+you need to do is enable access to the controller functions using a custom `routes.yml` file
+
+```yaml
+
+---
+Name: directoryroutes
+After: framework/routes#coreroutes
+---
+Director:
+  rules:
+    'code/$ID!': 'TaxonomyDirectoryController'
+    
+```
+
+In this example, any request made to `/code/<TAG>` would render a page which contains a list of pages that uses the
+Taxonomy Term specified by `<TAG>`. You can override the provided template `TaxonomyDirectory.ss` in your own theme.
+
+Currently the following variables are available to the template;
+1. `Title` - the Taxonomy Term you are searching for
+1. `Term` - the Taxonomy Term you are searching for
+1. `Pages` - a list of `Page` objects
+
+An example for a template;
+```html
+
+<h1>Taxonomy directory</h1>
+
+<h2>Results for '$Term'</h2>
+
+<ul>
+<% loop $Pages %>
+    <li><a href="$Link">$Title</a></li>
+<% end_loop %>
+</ul>
+
+
+```
+
+
+Note: the default directory implementation assumes that you've setup the reverse relation specified by `BasePage`.  

--- a/templates/Layout/TaxonomyDirectory.ss
+++ b/templates/Layout/TaxonomyDirectory.ss
@@ -1,0 +1,9 @@
+<h1>Taxonomy directory</h1>
+
+<h2>Results for '$Term'</h2>
+
+<ul>
+<% loop $Pages %>
+    <li><a href="$Link">$Title</a></li>
+<% end_loop %>
+</ul>


### PR DESCRIPTION
This PR would create a default implementation for the Taxonomy Directory page as suggested in the documentation. But except for a Page Type it uses a standard controller that has to be enabled using a director route configuration.