### PR TITLE
remove images from expose to prevent missing dir errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev"
-        },
-        "expose": [
-            "images"
-        ]
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Currently this throws a `No such file or directory` when trying to expose the dir, as it is no longer present in the repo.