### PR TITLE
FIX Revert removed title and summary for userhelp

### DIFF
--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -1,3 +1,6 @@
+title: Taxonomies
+summary: Add and edit simple taxonomies in the CMS.
+
 # Creating and using taxonomies
 
 ## In this section:


### PR DESCRIPTION
Readded as userhelp.silverstripe.org relies on this title and summary to be pulled in for the home page.