### PR TITLE
Adds a URLSegment to option to term directory

### DIFF
--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -201,5 +201,23 @@ An example for a template;
 
 ```
 
+#### Using a URL Segment
+The provided directory implementation has an option to use a URL-friendly field instead of `Name`. You can enable this in the above example by adding this to your project config `.yml`
+```yaml
+SilverStripe\Taxonomy\Controllers\TaxonomyDirectoryController:
+  lookup_relation_field: 'Terms.URLSegment'
+SilverStripe\Taxonomy\TaxonomyTerm:
+  extensions:
+    - SilverStripe\Taxonomy\Extensions\TaxonomyTermUrlExtension
+```
 
-Note: the default directory implementation assumes that you've setup the reverse relation specified by `BasePage`.  
+Note: the default directory implementation assumes that you've setup a relation called `Terms` in your `Page.php` as in the example above.
+
+If you're using a different class to `Page`, such as the cwp/cwp module which defines the `Terms` relation on the `BasePage` class you can specify the class using `directory_class` as below
+```yaml
+SilverStripe\Taxonomy\Controllers\TaxonomyDirectoryController:
+  directory_class: CWP\CWP\PageTypes\BasePage
+SilverStripe\Taxonomy\TaxonomyTerm:
+  extensions:
+    - SilverStripe\Taxonomy\Extensions\TaxonomyTermUrlExtension
+```

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -17,3 +17,5 @@ en:
       one: 'A Taxonomy Type'
       other: '{count} Taxonomy Types'
     SINGULARNAME: 'Taxonomy Type'
+  SilverStripe\Taxonomy\TaxonomyTermUrlExtension:
+    LeaveBlankLabel: 'Leave blank to generate from name'

--- a/src/Controllers/TaxonomyDirectoryController.php
+++ b/src/Controllers/TaxonomyDirectoryController.php
@@ -6,6 +6,7 @@ use Page;
 use PageController;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
@@ -20,6 +21,19 @@ if (!class_exists(PageController::class)) {
  */
 class TaxonomyDirectoryController extends PageController
 {
+    /**
+     * The class (e.g. Page) that has a relation to TaxonomyTerms
+     * The name of the relation on this class should be defined in $lookup_relation_field
+     * @config
+     */
+    private static $directory_class = 'Page';
+
+    /**
+     * The name of the TaxonomyTerm relation and field to expect in the URL
+     * e.g. Terms.Name or Tags.URLSegment
+     * @config
+     */
+    private static $lookup_relation_field = 'Terms.Name';
 
     private static $allowed_actions = array(
         'index'
@@ -29,7 +43,9 @@ class TaxonomyDirectoryController extends PageController
     {
         $termString = $request->param('ID');
 
-        $pages = Page::get()->filter(['Terms.Name' => $termString]);
+        $field = $this->config()->get('lookup_relation_field');
+        $class = $this->config()->get('directory_class');
+        $pages = DataObject::get($class)->filter([$field => $termString]);
 
         return $this->customise(new ArrayData(array(
             'Title' => $termString,

--- a/src/Extensions/TaxonomyTermUrlExtension.php
+++ b/src/Extensions/TaxonomyTermUrlExtension.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SilverStripe\Taxonomy\Extensions;
+
+use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Taxonomy\TaxonomyTerm;
+use SilverStripe\View\Parsers\URLSegmentFilter;
+
+/**
+* Adds a URLSegment to TaxonomyTerm that gets
+* generated from the name if not specified.
+*
+* @package taxonomy
+*/
+class TaxonomyTermUrlExtension extends DataExtension
+{
+    private static $db = array(
+        'URLSegment' => 'Varchar(255)',
+    );
+
+    public function updateCMSFields(FieldList $fields)
+    {
+        $field = $fields->dataFieldByName('URLSegment');
+        if ($field) {
+            $field->setDescription(_t(
+                __CLASS__ . '.LeaveBlankLabel',
+                'Leave blank to generate from name'
+            ));
+            $fields->insertAfter('Name', $field);
+        }
+    }
+
+    /**
+     *  Set the URL segment allowing filtering by url slug
+     *
+     *  {@inheritDoc}
+     */
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+        // Write the URLSegment to allow for Taxonomy navigation only if one is not supplied
+        if ($this->owner->Name && $this->owner->URLSegment == null) {
+            $filter = URLSegmentFilter::create();
+            $filteredTitle = $filter->filter($this->owner->Name);
+
+            // Fallback to generic name if path is empty (= no valid, convertable characters)
+            if (!$filteredTitle || $filteredTitle == '-' || $filteredTitle == '-1') {
+                $id = $this->owner->ID ? $this->owner->ID : 1;
+                $filteredTitle = "term-$id";
+            }
+
+            $this->owner->setField('URLSegment', $filteredTitle);
+        }
+        // Ensure that this object has a non-conflicting URLSegment value.
+        $count = 2;
+        while (TaxonomyTerm::get()->filter(['URLSegment' => $this->owner->URLSegment])->exclude(array('ID' => $this->owner->ID))->exists()) {
+            $this->owner->setField('URLSegment', preg_replace('/-[0-9]+$/', null, $this->owner->URLSegment) . '-' . $count);
+            $count++;
+        }
+    }
+}

--- a/tests/TaxonomyTermUrlExtensionTest.php
+++ b/tests/TaxonomyTermUrlExtensionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SilverStripe\Taxonomy\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Taxonomy\TaxonomyTerm;
+use SilverStripe\Taxonomy\Extensions\TaxonomyTermUrlExtension;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Core\Extensible;
+
+class TaxonomyTermUrlExtensionTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+    protected static $required_extensions = [TaxonomyTerm::class => [TaxonomyTermUrlExtension::class]];
+
+    public function testGeneratesUrl()
+    {
+        $term = new TaxonomyTerm();
+        $term->Name = 'Test 1';
+        $term->write();
+
+        // Reload the model
+        $term = DataObject::get_by_id(TaxonomyTerm::class, $term->ID);
+        $this->assertNotNull($term);
+        $this->assertEquals('Test 1', $term->Name);
+        $this->assertEquals('test-1', $term->URLSegment);
+    }
+
+    public function testGeneratesUniqueUrls()
+    {
+        $term1 = new TaxonomyTerm();
+        $term1->Name = 'Testing';
+        $term1->write();
+
+        $term2 = new TaxonomyTerm();
+        $term2->Name = 'Testing'; // intentionally the same
+        $term2->write();
+
+        // Reload the model
+        $term2 = DataObject::get_by_id(TaxonomyTerm::class, $term2->ID);
+        $this->assertNotNull($term2);
+        $this->assertEquals('Testing', $term2->Name);
+        $this->assertEquals('testing-2', $term2->URLSegment);
+    }
+
+    public function testRespectsSuppliedUrl()
+    {
+        $term = new TaxonomyTerm();
+        $term->Name = 'Test 1';
+        $term->URLSegment = 'something supplied';
+        $term->write();
+
+        // Reload the model
+        $term = DataObject::get_by_id(TaxonomyTerm::class, $term->ID);
+        $this->assertNotNull($term);
+        $this->assertEquals('Test 1', $term->Name);
+        $this->assertEquals('something supplied', $term->URLSegment);
+
+        // Check it doesn't overwrite if saved multiple times
+        $term->Name = 'Test changed';
+        $term->write();
+
+        $term = DataObject::get_by_id(TaxonomyTerm::class, $term->ID);
+        $this->assertNotNull($term);
+        $this->assertEquals('Test changed', $term->Name);
+        $this->assertEquals('something supplied', $term->URLSegment);
+    }
+
+    public function testGeneratesUniqueUrlIfSuppliedIsUsed()
+    {
+        $term1 = new TaxonomyTerm();
+        $term1->Name = 'Test 1';
+        $term1->URLSegment = 'supplied-test';
+        $term1->write();
+
+        $term2 = new TaxonomyTerm();
+        $term2->Name = 'Test 2';
+        $term2->URLSegment = 'supplied-test'; // intentionally the same
+        $term2->write();
+
+        // Reload the model
+        $term2 = DataObject::get_by_id(TaxonomyTerm::class, $term2->ID);
+        $this->assertNotNull($term2);
+        $this->assertEquals('Test 2', $term2->Name);
+        $this->assertEquals('supplied-test-2', $term2->URLSegment);
+    }
+
+    public function testGeneratesUrlWhenNameIsInvalid()
+    {
+        $term = new TaxonomyTerm();
+        $term->Name = '##';
+        $term->write();
+
+        // Reload the model
+        $term = DataObject::get_by_id(TaxonomyTerm::class, $term->ID);
+        $this->assertNotNull($term);
+        $this->assertEquals('##', $term->Name);
+        $this->assertEquals('term-1', $term->URLSegment);
+
+        $term = new TaxonomyTerm();
+        $term->Name = ' ';
+        $term->write();
+
+        // Reload the model
+        $term = DataObject::get_by_id(TaxonomyTerm::class, $term->ID);
+        $this->assertNotNull($term);
+        $this->assertEquals(' ', $term->Name);
+        $this->assertEquals('term-2', $term->URLSegment);
+    }
+}


### PR DESCRIPTION
Adds an option to the provided directory implementation to use a URLSegment instead of the name field.
The URL segment automatically gets generated from the name if a value isn't specified.

Provides a SS4 implementation for https://github.com/silverstripe/silverstripe-taxonomy/issues/44