### PR TITLE
Update for 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION="4.0.x-dev"
+    - COMPOSER_ROOT_VERSION="2.1.x-dev"
 
 matrix:
   include:


### PR DESCRIPTION
composer.json does not need to be changed
```
    "require": {
        "silverstripe/framework": "^4",
        "silverstripe/admin": "^1.0.2"
    },
```

Previous value of 4.0.x-dev was incorrect