### PR TITLE
v2.1 Add docblocks to TaxonomyTerm and Type

### DIFF
--- a/src/TaxonomyTerm.php
+++ b/src/TaxonomyTerm.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Taxonomy;
 
+use SilverStripe\ORM\HasManyList;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
 use SilverStripe\ORM\Hierarchy\Hierarchy;
@@ -16,6 +17,11 @@ use SilverStripe\Security\PermissionProvider;
  * Represents a single taxonomy term. Can be re-ordered in the CMS, and the default sorting is to use the order as
  * specified in the CMS.
  *
+ * @property string $Name
+ * @property int $ParentID
+ * @property int $Sort
+ * @property int $TypeID
+ * @method HasManyList|TaxonomyTerm[] Children()
  * @method TaxonomyTerm Parent()
  * @package taxonomy
  */

--- a/src/TaxonomyType.php
+++ b/src/TaxonomyType.php
@@ -7,6 +7,8 @@ use SilverStripe\ORM\DataObject;
 /**
  * Represents a type of taxonomy, which can be configured in the CMS. This can be used to group similar
  * taxonomy terms together.
+ *
+ * @property string $Name
  */
 class TaxonomyType extends DataObject
 {


### PR DESCRIPTION
Very useful for those of us using PHPStorm, or other IDEs that consume `@property` and `@method` declarations.

No functional changes.