### PR TITLE
DOCS Change "SilverStripe" to "Silverstripe" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 ## Introduction
 
-The Taxonomy module add the capability to add and edit simple taxonomies within SilverStripe.
+The Taxonomy module add the capability to add and edit simple taxonomies within Silverstripe.
 
 ## Requirements
 
- * SilverStripe 4.0+
- * SilverStripe Admin Module 1.0.2+
+ * Silverstripe 4.0+
+ * Silverstripe Admin Module 1.0.2+
  
- **Note:** this version is compatible with SilverStripe 4. For SilverStripe 3, please see [the 1.x release line](https://github.com/silverstripe/silverstripe-taxonomy/tree/1.2).
+ **Note:** this version is compatible with Silverstripe 4. For Silverstripe 3, please see [the 1.x release line](https://github.com/silverstripe/silverstripe-taxonomy/tree/1.2).
 
 ## Features
 


### PR DESCRIPTION
There was a relatively recent branding change from "SilverStripe" to "Silverstripe". This PR makes that change in the readme.

Note that the repository's description also still uses the old "SilverStripe" capitalisation.
![image](https://user-images.githubusercontent.com/36352093/150060756-fd04e845-c0ea-4e20-be6b-0d3128577893.png)

See also silverstripe/silverstripe-framework#10206