### PR TITLE
MNT Fix behat test to correctly identify tab

### DIFF
--- a/tests/behat/features/create-taxonomies.feature
+++ b/tests/behat/features/create-taxonomies.feature
@@ -21,7 +21,8 @@ Feature: Create taxonomies
     And I press the "Log in as someone else" button
     And I am logged in with "EDITOR" permissions
     When I go to "/admin/taxonomy"
-    Then I should see the ".current[aria-controls='Taxonomy_Terms']" element
+    # Check we're in the taxonomy terms tab by default
+    Then I should see the "li.current a.active[title='Taxonomy Terms']" element
     When I press the "Add Taxonomy Term" button
     And I fill in "Name" with "My taxonomy term"
     And I select "My taxonomy type" from "Type"


### PR DESCRIPTION
This was relying on an element ID that is no longer determined the same way it used to be. Looks like this changes when jQuery UI was updated.

When merged up, this will solve the broken build in the CMS 5 branches as well.

Fixes https://github.com/silverstripe/silverstripe-taxonomy/actions/runs/4130227905/jobs/7159342797
> Element .current[aria-controls='Taxonomy_Terms'] not found

## PRs
- https://github.com/silverstripeltd/product-issues/issues/676