### PR TITLE
DEP Update deps to specify new auto-scaffolded has-one field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
-        "silverstripe/admin": "^2"
+        "silverstripe/framework": "^5.2",
+        "silverstripe/admin": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/tests/behat/features/create-taxonomies.feature
+++ b/tests/behat/features/create-taxonomies.feature
@@ -25,7 +25,9 @@ Feature: Create taxonomies
     Then I should see the "li.current a.active[title='Taxonomy Terms']" element
     When I press the "Add Taxonomy Term" button
     And I fill in "Name" with "My taxonomy term"
-    And I select "My taxonomy type" from "Type"
+    And I fill in "Form_ItemEditForm_TypeID__input" with "My taxonomy type"
+    And I wait for 3 seconds
+    And I press the "Enter" key globally
     And I press the "Create" button
     When I follow "Taxonomy Terms"
     Then I should see "My taxonomy term"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/174

Fixes https://github.com/silverstripe/silverstripe-taxonomy/actions/runs/7438121052/job/20241493151

Broke because of new auto-scaffolded has-one field

Fix is similar to what was done here https://github.com/silverstripe/silverstripe-siteconfig/pull/149/files#diff-d7e7fec58ef8003b1c4632bac5cf55c9b270282ea8001672d909bec8e5f028d9R51