### PR TITLE
API Add new configuration for use in CMSMain-like admin

### DIFF
--- a/src/TaxonomyTerm.php
+++ b/src/TaxonomyTerm.php
@@ -60,12 +60,20 @@ class TaxonomyTerm extends DataObject implements PermissionProvider
 
     private static $default_sort = 'Sort';
 
+    private static string $sort_field = 'Sort';
+
     private static $summary_fields = array(
         'Name' => 'Name',
         'Type.Name' => 'Type'
     );
 
     private static $type_inheritance_enabled = true;
+
+    /**
+     * Css class attached to icons in a CMSMain tree. Also supports font-icon set.
+     * Overrides cms_icon for most purposes if set on the same class
+     */
+    private static string $cms_icon_class = 'font-icon-tag';
 
     public function getCMSFields()
     {


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-taxonomy/pull/125

Reflects changes in https://github.com/silverstripe/silverstripe-cms/pull/3017 and https://github.com/silverstripe/silverstripe-framework/pull/11439

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947