### PR TITLE
ENH Add indexes for "Name" column for taxonomies

### DIFF
--- a/src/TaxonomyTerm.php
+++ b/src/TaxonomyTerm.php
@@ -58,6 +58,10 @@ class TaxonomyTerm extends DataObject implements PermissionProvider
         'TaxonomyName' => 'Text'
     );
 
+    private static array $indexes = [
+        'Name' => true,
+    ];
+
     private static $default_sort = 'Sort';
 
     private static string $sort_field = 'Sort';

--- a/src/TaxonomyType.php
+++ b/src/TaxonomyType.php
@@ -17,4 +17,8 @@ class TaxonomyType extends DataObject
     private static $db = array(
         'Name' => 'Varchar(255)'
     );
+
+    private static array $indexes = [
+        'Name' => true,
+    ];
 }


### PR DESCRIPTION
For `TaxonomyTerm` this is commonly used to filter via the searchable dropdown field.
For `TaxonomyType` it's relatively common to filter the terms by `Type.Name = 'some name'`

## Issue

- https://github.com/silverstripe/.github/issues/414